### PR TITLE
Lwdev 9711 set accuracy back to 8

### DIFF
--- a/src/Lykke.Service.Qtum.Api.Core/Domain/Assets/Qtum.cs
+++ b/src/Lykke.Service.Qtum.Api.Core/Domain/Assets/Qtum.cs
@@ -20,7 +20,7 @@
         /// <inheritdoc/>
         public int Accuracy
         {
-            get => 0;
+            get => 8;
         }
 
         /// <inheritdoc/>

--- a/src/Lykke.Service.Qtum.Api.Core/Helpers/UnixTimeHelper.cs
+++ b/src/Lykke.Service.Qtum.Api.Core/Helpers/UnixTimeHelper.cs
@@ -8,8 +8,7 @@ namespace Lykke.Service.Qtum.Api.Core.Helpers
 
         public static DateTime UnixTimeStampToDateTime(double unixTimeStamp)
         {
-            _dtDateTime = _dtDateTime.AddSeconds(unixTimeStamp);
-            return _dtDateTime;
+            return _dtDateTime.AddSeconds(unixTimeStamp);
         }
 
         public static double DateTimeToUnixTimeStamp(DateTime dateTime)


### PR DESCRIPTION
Also fix UnixTimeHelper unrepresentable datetime issue [LWDEV-9712](https://lykkex.atlassian.net/browse/LWDEV-9712)